### PR TITLE
feat: automatically add the x-msw-bypass

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,11 +234,24 @@ export async function testApiHandler<NextResponseJsonType = any>({
     });
 
     const localUrl = `http://localhost:${port}`;
+    const defaultInit: RequestInit = {
+      headers: {
+        'x-msw-bypass': 'true'
+      }
+    };
 
     await new Promise((resolve, reject) => {
       deferredReject = reject;
       test({
-        fetch: async (init?: RequestInit) => {
+        fetch: async (customInit?: RequestInit) => {
+          const init: RequestInit = {
+            ...defaultInit,
+            ...customInit,
+            headers: {
+              ...defaultInit.headers,
+              ...customInit?.headers
+            }
+          };
           return (fetch(localUrl, init) as FetchReturnType<NextResponseJsonType>).then(
             (res) => {
               // ? Lazy load (on demand) the contents of the `cookies` field


### PR DESCRIPTION
When using this library alongside with [MSW](https://mswjs.io/) to mock external API calls, we need to whitelist the request made by NTARH. MSW automatically bypasses requests containing the `x-msw-bypass` header.

As there should not be any reason for MSW to intercept requests made by NTARH, we now automatically add this header when sending the request to the handler.

---

- [x] I have read **[CONTRIBUTING.md][1]**
- [x] This PR is not security related (see [SECURITY.md][2])

[1]: /CONTRIBUTING.md
[2]: /SECURITY.md
