### PR TITLE
fix(next): add support for Next.js 13.5.4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,9 +166,11 @@ export async function testApiHandler<NextResponseJsonType = any>({
 
   try {
     if (!apiResolver) {
-      // ? The following is for next@>=12.1.0:
+      // ? The following is for next@>=13.5.4:
       // @ts-ignore: conditional import for earlier next versions
-      ({ apiResolver } = await import('next/dist/server/api-utils/node.js')
+      ({ apiResolver } = await import('next/dist/server/api-utils/node/api-resolver.js')
+        // ? The following is for next@>=12.1.0:
+        .catch(tryImport('next/dist/server/api-utils/node.js'))
         // ? The following is for next@<12.1.0 >=11.1.0:
         .catch(tryImport('next/dist/server/api-utils.js'))
         // ? The following is for next@<11.1.0 >=9.0.6:


### PR DESCRIPTION
<!-- Add a brief description of your PR here -->
This PR introduces support for the latest release of Next.js where they changed the file structure, see ["misc: refactor node utils"](https://github.com/vercel/next.js/pull/56096).

<!-- If this PR closes any issues, please enumerate them; i.e. "Closes #4" -->

<!-- If this PR involves or references any other issues, list them as well -->

---

<!-- Replace `[ ]` with `[x]` in all the following boxes that apply to you -->

- [x] I have read **[CONTRIBUTING.md][1]**
- [x] This PR is not security related (see [SECURITY.md][2])

[1]: /CONTRIBUTING.md
[2]: /SECURITY.md
