### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/is-next-compat.yml
+++ b/.github/workflows/is-next-compat.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Gather metadata
         id: set-matrix
         run: |
-          echo "::set-output name=node-matrix::{\"node\":[$NODE_OLDER_VERSIONS, \"$NODE_CURRENT_VERSION\"]}"
+          echo "node-matrix={\"node\":[$NODE_OLDER_VERSIONS, \"$NODE_CURRENT_VERSION\"]}" >> $GITHUB_OUTPUT
           ! [ -z "$DEBUG" ] && echo "set-output name=node-matrix::{\"node\":[$NODE_OLDER_VERSIONS, \"$NODE_CURRENT_VERSION\"]}" || true
 
   check-compat:

--- a/.github/workflows/run-apollo-app-example.yml
+++ b/.github/workflows/run-apollo-app-example.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Gather metadata
         id: set-matrix
         run: |
-          echo "::set-output name=node-matrix::{\"node\":[$NODE_OLDER_VERSIONS, \"$NODE_CURRENT_VERSION\"]}"
+          echo "node-matrix={\"node\":[$NODE_OLDER_VERSIONS, \"$NODE_CURRENT_VERSION\"]}" >> $GITHUB_OUTPUT
           ! [ -z "$DEBUG" ] && echo "set-output name=node-matrix::{\"node\":[$NODE_OLDER_VERSIONS, \"$NODE_CURRENT_VERSION\"]}" || true
 
   check-compat:

--- a/.github/workflows/run-apollo-pages-example.yml
+++ b/.github/workflows/run-apollo-pages-example.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Gather metadata
         id: set-matrix
         run: |
-          echo "::set-output name=node-matrix::{\"node\":[$NODE_OLDER_VERSIONS, \"$NODE_CURRENT_VERSION\"]}"
+          echo "node-matrix={\"node\":[$NODE_OLDER_VERSIONS, \"$NODE_CURRENT_VERSION\"]}" >> $GITHUB_OUTPUT
           ! [ -z "$DEBUG" ] && echo "set-output name=node-matrix::{\"node\":[$NODE_OLDER_VERSIONS, \"$NODE_CURRENT_VERSION\"]}" || true
 
   check-compat:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


