### PR TITLE
Fix for multiZoneDraftMode (issue 1076)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -597,7 +597,7 @@ export async function testApiHandler<NextResponseJsonType = any>({
               res,
               finalParameters,
               pagesHandler,
-              undefined as any,
+              {} as any,
               !!rejectOnHandlerError
             ).catch((error: unknown) => handleError(res, error, deferredReject));
           })


### PR DESCRIPTION
NextJS apparently now reads  `multiZoneDraftMode` from `apiContext`
Inside NTARH, `undefined` is passed as `apiContext`, which causes Next to react `undefined. multiZoneDraftMode` which crashes the test.

The fix that works for us is to pass `{}` as `apiContext`, `multiZoneDraftMode` will still be undefined, but we don't get a "null"pointer
---


- [x] I have read **[CONTRIBUTING.md][1]**.
- [x] This PR is not security related (see [SECURITY.md][2]).

[1]: /CONTRIBUTING.md
[2]: /SECURITY.md
