### PR TITLE
perf: use direct invocation instead of HTTP server (#1225)

### DIFF
--- a/test/unit-direct-invocation.test.ts
+++ b/test/unit-direct-invocation.test.ts
@@ -1,0 +1,65 @@
+import { isolatedImport } from 'testverse:util.ts';
+
+const importNtarh = () =>
+  isolatedImport<typeof import('universe')>('universe').testApiHandler;
+
+describe('direct invocation (no HTTP server)', () => {
+  it('executes handlers without starting an HTTP server; basic response and cookies work', async () => {
+    expect.hasAssertions();
+
+    const http = require('node:http');
+    const spy = jest.spyOn(http, 'createServer');
+
+    await expect(
+      importNtarh()({
+        pagesHandler: async (_req, res) => {
+          res.setHeader('Set-Cookie', ['__has=yes; Path=/']);
+          res.status(200).json({ ok: true });
+        },
+        test: async ({ fetch }) => {
+          const res = await fetch();
+          expect(spy).not.toHaveBeenCalled();
+          expect(res.ok).toBeTrue();
+          expect(res.cookies[0]?.__has).toBe('yes');
+          await expect(res.json()).resolves.toStrictEqual({ ok: true });
+        }
+      })
+    ).resolves.toBeUndefined();
+
+    spy.mockRestore();
+  });
+
+  it('handles HEAD responses with empty bodies (pages router)', async () => {
+    expect.hasAssertions();
+
+    await expect(
+      importNtarh()({
+        pagesHandler: async (_req, res) => {
+          res.status(200).send('should not be visible');
+        },
+        test: async ({ fetch }) => {
+          const res = await fetch({ method: 'HEAD' });
+          await expect(res.text()).resolves.toBe('');
+        }
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('handles HEAD responses with empty bodies (app router)', async () => {
+    expect.hasAssertions();
+
+    await expect(
+      importNtarh()({
+        appHandler: {
+          async HEAD() {
+            return new Response('should not be visible');
+          }
+        },
+        test: async ({ fetch }) => {
+          const res = await fetch({ method: 'HEAD' });
+          await expect(res.text()).resolves.toBe('');
+        }
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/test/unit-index-imports.test.ts
+++ b/test/unit-index-imports.test.ts
@@ -339,28 +339,14 @@ const jestExpectationContextFactory =
 afterEach(() => resetMockResolverFlags());
 
 describe('::testApiHandler', () => {
-  it('sanity checks addr value when server starts listening', async () => {
+  it('direct invocation: basic pages handler works', async () => {
     expect.hasAssertions();
-
-    const http = require('node:http');
-    const oldCreateServer = http.createServer;
-
-    jest.spyOn(http, 'createServer').mockImplementation((...args: unknown[]) => {
-      const server = oldCreateServer(...args);
-      server.address = () => undefined;
-      return server;
-    });
-
     await expect(
       importNtarh()({
         pagesHandler: getPagesHandler(),
         test: async ({ fetch }) => void (await fetch())
       })
-    ).rejects.toMatchObject({
-      message: expect.stringContaining(
-        'assertion failed unexpectedly: server did not return AddressInfo instance'
-      )
-    });
+    ).resolves.toBeUndefined();
   });
 
   // eslint-disable-next-line jest/prefer-lowercase-title


### PR DESCRIPTION
This commit improves performance by avoiding the overhead of spinning up a real HTTP server for testing.

**Testing note:** All tests pass. However, the project has no benchmarks, making it difficult to assess performance-oriented changes like this. In principle it should be faster, but I don't have empirical support for that yet.

Closes #1225

- [x] I have read **[CONTRIBUTING.md][1]**.
- [x] This PR is not security related (see [SECURITY.md][2]).

[1]: /CONTRIBUTING.md
[2]: /SECURITY.md
